### PR TITLE
Fix for compile errors in UserControllerTests

### DIFF
--- a/TextCrunch/UserController.swift
+++ b/TextCrunch/UserController.swift
@@ -10,7 +10,7 @@ import Foundation
 
 
 //The base UserController class for non-social network user management.
-class UserController{
+public class UserController{
     
     let LOGINFAIL_MISC = -1 //Login error code for unknown error.
     let LOGINFAIL_PASSWORD = 0 //Login error code for if the login password is not correct.
@@ -20,13 +20,17 @@ class UserController{
     
     let CREATEFAIL_MISC = -1 //Account creation error code for unknown error.
     let CREATEFAIL_EMAILEXISTS = 10 //Account creation error code for if the email is already in use.
-    let CREATESUCCESS = 11 //Account creation code for a successful creation.
-    
+    public let CREATESUCCESS = 11 //Account creation code for a successful creation.
+	
+	public init()
+	{
+	}
+	
     func loginUser(user: UserModel) -> Int{
         return self.LOGINFAIL_MISC
     }
     
-    func createUserAccount(user: UserModel) -> Int{
+    public func createUserAccount(user: UserModel) -> Int{
         return self.CREATEFAIL_MISC
     }
     

--- a/TextCrunch/UserModel.swift
+++ b/TextCrunch/UserModel.swift
@@ -9,14 +9,14 @@
 import Foundation
 import CoreLocation
 
-class UserModel {
+public class UserModel {
     var email: String
     var pass: String
     var accountId: String
     var paymentToken: String
     var currentLocation: CLLocation?
     
-    init(email: String, pass: String){
+    public init(email: String, pass: String){
         self.email = email
         self.pass = pass
         self.accountId = ""

--- a/TextCrunchTests/UserControllerTests.swift
+++ b/TextCrunchTests/UserControllerTests.swift
@@ -9,7 +9,7 @@
 import UIKit
 import XCTest
 
-//import TextCrunch
+import TextCrunch
 
 class UserControllerTests: XCTestCase {
 
@@ -43,7 +43,7 @@ class UserControllerTests: XCTestCase {
         var testUser = UserModel(email: "testingemail@testing.com", pass: "password")
         var controller = UserController()
         var result = controller.createUserAccount(testUser)
-        XCTAssert(result == controller.CREATESUCCESS, "Account created.")
+		XCTAssert(result == controller.CREATESUCCESS, "Account created.")
         
     }
     


### PR DESCRIPTION
There were compile errors in the UserControllerTests. Classes and methods must be public to be viewed in other modules (eg. the test module). The TextCrunch module must also be imported before classes within TextCrunch can be accessed. 