### PR TITLE
New Negotiation "Payment" Bug

### DIFF
--- a/TextCrunch/NegotiationViewController.swift
+++ b/TextCrunch/NegotiationViewController.swift
@@ -475,6 +475,12 @@ class NegotiationViewController : UIViewController, UITableViewDataSource, UITab
     // authorization and then prepares a prepareCharge
     func prepareBuyer() {
         
+        // Make sure that we're persisting a new negotiation before any payment
+        // stuff goes down
+        if self.negotiation.isDirty() {
+            self.negotiation.save()
+        }
+        
         PayPalMobile.preconnectWithEnvironment(PayPalEnvironmentSandbox)
         
         var buyer: User? = negotiation.listing.buyer?.fetchIfNeeded() as? User

--- a/TextCrunchTests/PaymentManagerTests.swift
+++ b/TextCrunchTests/PaymentManagerTests.swift
@@ -18,7 +18,7 @@ class PaymentManagerTests: XCTestCase {
     var buyerEmail = "me@derekdowling.com"
     var buyerPW = "test1234"
     
-    var sellerEmail = "me-buyer2@derekdowling.com"
+    var sellerEmail = "me@derekdowling.com"
     var sellerPW = "test4567"
     
     var buyer: PFUser!
@@ -36,22 +36,22 @@ class PaymentManagerTests: XCTestCase {
         
         var query = User.query()
         query.whereKey("email", equalTo:buyerEmail)
-        buyer = query.findObjects().first as PFUser
+        buyer = query.findObjects().first as User
         
         print(buyer)
         
         var query2 = User.query()
         query2.whereKey("email", equalTo:sellerEmail)
-        seller = query2.findObjects().first as PFUser
+        seller = query2.findObjects().first as User
         
         var bookQ = PFQuery(className:"Book")
-        var book = bookQ.getObjectWithId("lVuQZZ9NKQ") as Book
+        var book = bookQ.getObjectWithId("gR493QRK6g") as Book
         
         listing = Listing()
         listing.buyer = buyer
         listing.seller = seller
         listing.book = book
-        listing.price = 20
+        listing.price = 20.00
         listing.save()
         
         negotiation = Negotiation()

--- a/TxtCrunchCloud/cloud/main.js
+++ b/TxtCrunchCloud/cloud/main.js
@@ -219,6 +219,7 @@ Parse.Cloud.define("prepareCharge", function (request, response) {
         var bookTitle = negotiation.get("listing").get("book").get("title");
         description = "Purchase for " + bookTitle;
 
+
         return refreshAccessToken(
             negotiation.get("buyer").get("buyerRefreshToken")
         );


### PR DESCRIPTION
I found this when trying to get some screen caps for the acceptance tests. This must have started when @Torboto fixed the negotiation logic. Basically the payment system tries to reference, in the case of a new negotiation, an unsaved Parse object which will have an undefined objectid. There is only one place where this can possibly occur so I'm doing a dirty check and then saving the object to prevent this if the payment flow is triggered.

Also fixed the PaymentTests to work again. Unfortunately I had to sour our Parse db with a bunch of test objects. I blame it on poor tear down.